### PR TITLE
Fix `raw_value`

### DIFF
--- a/src/sub_feature/mod.rs
+++ b/src/sub_feature/mod.rs
@@ -129,7 +129,7 @@ impl<'a> SubFeatureRef<'a> {
     pub fn raw_value(&self) -> Result<f64> {
         let mut result = 0.0_f64;
 
-        let r = api_access_lock().lock().map(move |_guard| unsafe {
+        let r = api_access_lock().lock().map(|_guard| unsafe {
             sensors_get_value(
                 self.feature.chip.as_ref(),
                 self.feature.as_ref().number,

--- a/src/sub_feature/mod.rs
+++ b/src/sub_feature/mod.rs
@@ -130,11 +130,7 @@ impl<'a> SubFeatureRef<'a> {
         let mut result = 0.0_f64;
 
         let r = api_access_lock().lock().map(|_guard| unsafe {
-            sensors_get_value(
-                self.feature.chip.as_ref(),
-                self.feature.as_ref().number,
-                &mut result,
-            )
+            sensors_get_value(self.feature.chip.as_ref(), self.number(), &mut result)
         })?;
         if r == 0 {
             Ok(result)
@@ -148,7 +144,7 @@ impl<'a> SubFeatureRef<'a> {
     /// See: [`sensors_set_value`].
     pub fn set_raw_value(&self, new_value: f64) -> Result<()> {
         let chip = self.feature.chip.as_ref();
-        let number = self.feature.as_ref().number;
+        let number = self.number();
         let r = api_access_lock()
             .lock()
             .map(move |_guard| unsafe { sensors_set_value(chip, number, new_value) })?;


### PR DESCRIPTION
Using a `move` closure here results in it always returning `0`, since it creates a copy of `result` rather than referencing it.